### PR TITLE
add Kubernetes Replication Controller and Service files

### DIFF
--- a/deployment/k8s-rc.json
+++ b/deployment/k8s-rc.json
@@ -1,0 +1,61 @@
+{
+	"kind":"ReplicationController",
+	"apiVersion":"v1beta3",
+	"metadata":{
+		"name":"qa-sample-service"
+	},
+	"spec":{
+		"replicas":1,
+		"selector":{
+			"name":"qa-sample-service"
+		},
+		"template":{
+			"metadata":{
+				"labels":{
+					"name":"qa-sample-service"
+				}
+				
+			},
+			"spec":{
+				"containers":[
+					{
+						"name":"qa-sample-service",
+						"image":"hidetosaito/qa-sample-service",
+						"imagePullPolicy":"Always",
+						"env":[
+							{
+								"name":"AWS_ACCESS_KEY_ID",
+								"value":"<your accesskey>"
+							},
+							{
+								"name":"AWS_SECRET_ACCESS_KEY",
+								"value":"<your secretkey>"
+							},
+							{
+								"name":"APP_SETTING",
+								"value":"config.DevelopmentContainerConfig"
+							},
+							{
+								"name":"PORT",
+								"value":"5000"
+							}
+							
+						],
+						"ports":[
+							{
+								"name":"http",
+								"containerPort":5000
+							}
+							
+						]
+						
+					}
+					
+				]
+				
+			}
+			
+		}
+		
+	}
+}

--- a/deployment/k8s-service.json
+++ b/deployment/k8s-service.json
@@ -1,0 +1,20 @@
+{
+	"apiVersion":"v1beta3",
+	"kind":"Service",
+	"metadata":{
+		"name":"qa-sample-service"
+	},
+	"spec":{
+		"ports":[
+			{
+				"protocol":"TCP",
+				"port":5000,
+				"nodePort":30080
+			}
+		],
+		"type":"NodePort",
+		"selector":{
+			"name":"qa-sample-service"
+		}
+	}
+}


### PR DESCRIPTION
Hi @msfuko @carol-hsu

Here is a sample of Kubernetes Replication Controller and Service for qa-sample-service.

## k8s-rc.json
it is a ordinary of Replication Controller setting, below environment variables are
- APP_SETTING --> choose config profile of ```DevelopmentContainerConfig``` to bind 0.0.0.0 instead of 127.0.0.1
- PORT --> flask setting, open HTTP port 5000

at this moment, Kubernetes minion just expose 5000/tcp, however you can access **inside of flannel network (192.168.0.0/16) only**


## k8s-service.json
it is a supplemental setting using Kubernetes Service (https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/user-guide/services.md)
it will bind **30080/tcp@minon-node** to **5000/tcp@docker** (you can check ```iptables -t nat -L``` DNAT rule).

so that you can access to qa-sample-service via http://one-of-minion:30080/ from outside, then Kubernetes service will dispatch to inside of docker via flannel. this is why **you can deploy many qa-sample-service on same node** even though qa-sample-service binds same 5000/tcp.


## problem ?
@msfuko , please help me to check, because i can access to "/" which returns "please use API" message correctly. however if i access to "/criteria" it will going to basic authentication, after that it will hang on my environment. not 100% sure it were caused by Kubernetes stack or flask or not. (it will totally hang, can't access even "/" anymore)

perhaps we may use nginx in front of flask, if you have a time, please check it.