### PR TITLE
add format validation support and change request API path

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,7 @@ class Config(object):
 
     DEBUG = True
     TESTING = False
+    KIND = 'zenoss'
 
 
 class ProductionConfig(Config):
@@ -58,6 +59,7 @@ class DevelopmentContainerConfig(DevelopmentConfig):
 class TestConfig(Config):
 
     TESTING = True
+    KIND = 'zenoss'
 
     # host
     HOST = '0.0.0.0'

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ class Config(object):
     TESTING = False
     KIND = 'zenoss'
 
+    #CACHE_DEFAULT_TIMEOUT = 500
+
 
 class ProductionConfig(Config):
 

--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ class ProductionConfig(Config):
     RESULT_TABLE = 'QAPortal-Staging-QAResult'
 
     # sqs
-    SQS_REGIOM = 'us-west-1'
+    SQS_REGION = 'us-west-1'
     SQS_NAME = 'QATaskQueue-Staging'
     
     # cache
@@ -45,7 +45,7 @@ class DevelopmentConfig(Config):
     RESULT_TABLE = 'QAPortal-POC-QAResult'
 
     # sqs
-    SQS_REGIOM = 'us-east-1'
+    SQS_REGION = 'us-east-1'
     SQS_NAME = 'QATaskQueue-POC'
     
     # cache
@@ -73,7 +73,7 @@ class TestConfig(Config):
     RESULT_TABLE = 'test-QAResult'
 
     # sqs
-    SQS_REGIOM = 'us-east-1'
+    SQS_REGION = 'us-east-1'
     SQS_NAME = 'test-POC'
     
     # cache

--- a/dcsqa/app.py
+++ b/dcsqa/app.py
@@ -9,6 +9,7 @@ from criteria import criteria_blueprint
 from raw import raw_blueprint
 from result import result_blueprint
 from auth import auth
+from cache import cache
 
 app = Flask(__name__)
 
@@ -22,7 +23,7 @@ def _get_url_prefix(request_type, version='v1'):
 
 def create_app(app_name='dcsqa', config='config.DevelopmentConfig'):
     app.config.from_object(config)
-    app.cache = Cache(app) 
+    cache.init_app(app)
 
     # register blueprint for each restful entry
     # http://flask.pocoo.org/docs/0.10/blueprints/

--- a/dcsqa/app.py
+++ b/dcsqa/app.py
@@ -13,15 +13,22 @@ from auth import auth
 app = Flask(__name__)
 
 
+def _get_url_prefix(request_type, version='v1'):
+    """return example would be /zenoss/v1/criteria
+    """
+    return '/{kind}/{version}/{request_type}'.\
+        format(kind=app.config['KIND'], version=version, request_type=request_type)
+
+
 def create_app(app_name='dcsqa', config='config.DevelopmentConfig'):
     app.config.from_object(config)
     app.cache = Cache(app) 
 
     # register blueprint for each restful entry
     # http://flask.pocoo.org/docs/0.10/blueprints/
-    app.register_blueprint(criteria_blueprint, url_prefix='/criteria')
-    app.register_blueprint(raw_blueprint, url_prefix='/raw')
-    app.register_blueprint(result_blueprint, url_prefix='/result')
+    app.register_blueprint(criteria_blueprint, url_prefix=_get_url_prefix('criteria'))
+    app.register_blueprint(raw_blueprint, url_prefix=_get_url_prefix('raw'))
+    app.register_blueprint(result_blueprint, url_prefix=_get_url_prefix('result'))
 
     return app
 

--- a/dcsqa/cache.py
+++ b/dcsqa/cache.py
@@ -1,0 +1,4 @@
+from flask.ext.cache import Cache
+
+# Refer to - https://github.com/thadeusb/flask-cache/issues/84
+cache = Cache()

--- a/dcsqa/criteria.py
+++ b/dcsqa/criteria.py
@@ -89,7 +89,7 @@ def set_criteria_by_ticketkey_host(ticket_key, host):
 
     # 5.
     cache.delete_memoized(get_all_criteria)
-    cache.delete_memoized(get_criteria_by_ticketkey, criteria['TicketKey'])
+    cache.delete_memoized(get_criteria_by_ticketkey, ticket_key)
     cache.delete_memoized(get_criteria_by_ticketkey_host, ticket_key, host)
 
     # 6.

--- a/dcsqa/criteria.py
+++ b/dcsqa/criteria.py
@@ -93,7 +93,7 @@ def set_criteria_by_ticketkey_host():
     cache.delete_memoized(get_criteria_by_ticketkey_host, criteria['TicketKey'], criteria['Host'])
 
     # 6.
-    queue = Queue(region_name=current_app.config['SQS_REGIOM'],
+    queue = Queue(region_name=current_app.config['SQS_REGION'],
                   queue_name=current_app.config['SQS_NAME'],
                   logger=current_app.logger)
     queue.push({key: data[key] for key in ['TicketKey', 'Host']})

--- a/dcsqa/dao/table.py
+++ b/dcsqa/dao/table.py
@@ -28,6 +28,7 @@ class DataTable(object):
             KeyConditionExpression=Key('TicketKey').eq(ticket_key)
         )
         if response['Count'] > 0:
+            self.logger.debug(response['Items'])
             return response['Items']
         else:
             self.logger.warn("there are no record TicketKey=%s in %s" % (ticket_key, self.table.name))
@@ -40,6 +41,7 @@ class DataTable(object):
         
         if response['Count'] > 0:
             items = response['Items']
+            self.logger.debug(items[0])
             #not return array
             return items[0]
         else:

--- a/dcsqa/dao/table.py
+++ b/dcsqa/dao/table.py
@@ -48,12 +48,13 @@ class DataTable(object):
             self.logger.warn("there are no record TicketKey=%s, Host=%s in %s" % (ticket_key, host, self.table.name))
             return None
         
-    def save(self, item):
+    def save(self, item, **kwargs):
         """
         Save item into Table
         :param item: (dict) of saved item
         :return:
         """
+        item.update(kwargs)
         response = self.table.put_item(Item=item)
         self.logger.info(response)
         return response

--- a/dcsqa/model/__init__.py
+++ b/dcsqa/model/__init__.py
@@ -31,7 +31,7 @@ class BaseObject(object):
             if isinstance(value, expected_type):
                 return self.properties.__setitem__(name, value)
             else:
-                current_app.logger.warn("Field {name} required in type {expected_type} but {current_type}, Skip".
+                current_app.logger.warn("Field {name} is required in type {expected_type} but {current_type}, Skip".
                                         format(name=name, expected_type=expected_type, current_type=type(value)))
 
     def get_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
@@ -39,7 +39,7 @@ class BaseObject(object):
         for name, (default_type, required) in self.props.items():
             if required and name not in self.properties:
                 rtype = getattr(self, 'resource_type', str(default_type))
-                raise ValueError("Properties {name} required in type {rtype}".
+                raise ValueError("Properties {name} is required in type {rtype}".
                                  format(name=name, rtype=rtype))
 
         current_app.logger.debug(json.dumps(self.properties, indent=indent, sort_keys=sort_keys, separators=separators))

--- a/dcsqa/model/__init__.py
+++ b/dcsqa/model/__init__.py
@@ -3,10 +3,13 @@ The class is the super class of all models, which will check the props map in su
 Using for validate whether the data type of props is expected
 """
 import json
+from abc import ABCMeta, abstractproperty
 from flask import current_app
 
 
 class BaseObject(object):
+
+    __metaclass__ = ABCMeta
 
     def __init__(self, **kwargs):
         # Cache the keys for validity checks
@@ -33,6 +36,10 @@ class BaseObject(object):
             else:
                 current_app.logger.warn("Field {name} is required in type {expected_type} but {current_type}, Skip".
                                         format(name=name, expected_type=expected_type, current_type=type(value)))
+
+    @abstractproperty
+    def props(self):
+        return dict()
 
     def get_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
         # check if the required fields are all in

--- a/dcsqa/model/__init__.py
+++ b/dcsqa/model/__init__.py
@@ -1,0 +1,47 @@
+"""
+The class is the super class of all models, which will check the props map in subclass.
+Using for validate whether the data type of props is expected
+"""
+import json
+from flask import current_app
+
+
+class BaseObject(object):
+
+    def __init__(self, **kwargs):
+        # Cache the keys for validity checks
+        self.__dict__['propnames'] = self.props.keys()
+
+        # result properties fields
+        self.__dict__['properties'] = {}
+
+        # set attributes
+        for k, v in kwargs.items():
+            self.__setattr__(k, v)
+
+    def __setattr__(self, name, value):
+        # not checking item, set attribute
+        if name not in self.propnames:
+            return dict.__setattr__(self, name, value)
+
+        else:
+            # check if the type matches expected_type, if no, bypass
+            expected_type = self.props[name][0]
+
+            if isinstance(value, expected_type):
+                return self.properties.__setitem__(name, value)
+            else:
+                current_app.logger.warn("Field {name} required in type {expected_type} but {current_type}, Skip".
+                                        format(name=name, expected_type=expected_type, current_type=type(value)))
+
+    def get_json(self, indent=4, sort_keys=True, separators=(',', ': ')):
+        # check if the required fields are all in
+        for name, (default_type, required) in self.props.items():
+            if required and name not in self.properties:
+                rtype = getattr(self, 'resource_type', str(default_type))
+                raise ValueError("Properties {name} required in type {rtype}".
+                                 format(name=name, rtype=rtype))
+
+        current_app.logger.debug(json.dumps(self.properties, indent=indent, sort_keys=sort_keys, separators=separators))
+        return self.properties
+

--- a/dcsqa/model/criteria.py
+++ b/dcsqa/model/criteria.py
@@ -4,8 +4,6 @@ from . import BaseObject
 class CriteriaData(BaseObject):
 
     props = {
-        'TicketKey': (basestring, True),
-        'Host': (basestring, True),
         'Alert': (bool, True),
         'Collector': (bool, True),
         'DeviceStatus': (bool, True),

--- a/dcsqa/model/criteria.py
+++ b/dcsqa/model/criteria.py
@@ -1,0 +1,20 @@
+from . import BaseObject
+
+
+class CriteriaData(BaseObject):
+
+    props = {
+        'TicketKey': (basestring, True),
+        'Host': (basestring, True),
+        'Alert': (bool, True),
+        'Collector': (bool, True),
+        'DeviceStatus': (bool, True),
+        'FileSystem': (bool, True),
+        'Processors': (bool, True),
+        'ProductionState': (bool, True),
+        'Template': (list, True),
+        'IPAddress': (list, True),
+        'Datacenter': (basestring, True),
+        'SystemName': (basestring, True),
+        'FQDN': (basestring, True)
+        }

--- a/dcsqa/model/raw.py
+++ b/dcsqa/model/raw.py
@@ -1,0 +1,20 @@
+from . import BaseObject
+
+
+class RawData(BaseObject):
+
+    props = {
+        'TicketKey': (basestring, True),
+        'Host': (basestring, True),
+        'Alert': (list, False),
+        'Collector': (basestring, False),
+        'DeviceStatus': (basestring, False),
+        'FileSystem': (dict, False),
+        'Processors': (int, False),
+        'ProductionState': (basestring, False),
+        'Template': (list, False),
+        'IPAddress': (basestring, False),
+        'Groups': (list, False),
+        'Systems': (list, False),
+        'DeviceName': (dict, False)
+        }

--- a/dcsqa/model/raw.py
+++ b/dcsqa/model/raw.py
@@ -4,8 +4,6 @@ from . import BaseObject
 class RawData(BaseObject):
 
     props = {
-        'TicketKey': (basestring, True),
-        'Host': (basestring, True),
         'Alert': (list, False),
         'Collector': (basestring, False),
         'DeviceStatus': (basestring, False),

--- a/dcsqa/model/result.py
+++ b/dcsqa/model/result.py
@@ -1,0 +1,20 @@
+from . import BaseObject
+
+
+class ResultData(BaseObject):
+
+    props = {
+        'TicketKey': (basestring, True),
+        'Host': (basestring, True),
+        'Alert': (int, False),
+        'Collector': (int, False),
+        'DeviceStatus': (int, False),
+        'FileSystem': (int, False),
+        'Processors': (int, False),
+        'ProductionState': (int, False),
+        'Template': (dict, False),
+        'IPAddress': (int, False),
+        'Groups': (int, False),
+        'Systems': (int, False),
+        'DeviceName': (int, False)
+        }

--- a/dcsqa/model/result.py
+++ b/dcsqa/model/result.py
@@ -4,8 +4,6 @@ from . import BaseObject
 class ResultData(BaseObject):
 
     props = {
-        'TicketKey': (basestring, True),
-        'Host': (basestring, True),
         'Alert': (int, False),
         'Collector': (int, False),
         'DeviceStatus': (int, False),

--- a/dcsqa/raw.py
+++ b/dcsqa/raw.py
@@ -6,7 +6,7 @@ from auth import auth
 from flask import request, Blueprint, current_app
 from dcsqa.dao.table import DataTable
 from dcsqa.model.raw import RawData
-
+from dcsqa.cache import cache
 
 raw_blueprint = Blueprint('raw', __name__)
 
@@ -16,7 +16,9 @@ raw_blueprint = Blueprint('raw', __name__)
 def before_request():
     current_app.logger.debug("user login - {user}".format(user=auth.username()))
 
+
 @raw_blueprint.route('', methods=['GET'])
+@cache.memoize()
 def get_all_raw():
     raw = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
@@ -26,6 +28,7 @@ def get_all_raw():
 
 
 @raw_blueprint.route('/<ticket_key>', methods=['GET'])
+@cache.memoize()
 def get_raw_by_ticketkey(ticket_key):
     raw = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
@@ -35,6 +38,7 @@ def get_raw_by_ticketkey(ticket_key):
 
 
 @raw_blueprint.route('/<ticket_key>/<host>', methods=['GET'])
+@cache.memoize()
 def get_raw_by_ticketkey_host(ticket_key, host):
     raw = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
@@ -52,6 +56,7 @@ def set_raw_by_ticketkey_host():
     #    2. JSON must be parsed successfully
     #    3. validate JSON string
     #    4. save to DB
+    #    5. purge cache
     #
 
     # 1.
@@ -77,6 +82,11 @@ def set_raw_by_ticketkey_host():
     dao = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
                     logger=current_app.logger)
-    result = dao.save(raw)
+    dao.save(raw)
+
+    # 5.
+    cache.delete_memoized(get_all_raw)
+    cache.delete_memoized(get_raw_by_ticketkey, raw['TicketKey'])
+    cache.delete_memoized(get_raw_by_ticketkey_host, raw['TicketKey'], raw['Host'])
 
     return response.created()

--- a/dcsqa/raw.py
+++ b/dcsqa/raw.py
@@ -47,8 +47,8 @@ def get_raw_by_ticketkey_host(ticket_key, host):
     return response.get_json(result)
 
 
-@raw_blueprint.route('', methods=['POST'])
-def set_raw_by_ticketkey_host():
+@raw_blueprint.route('/<ticket_key>/<host>', methods=['POST'])
+def set_raw_by_ticketkey_host(ticket_key, host):
 
     #
     # [Validation]
@@ -82,11 +82,11 @@ def set_raw_by_ticketkey_host():
     dao = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RAW_TABLE'],
                     logger=current_app.logger)
-    dao.save(raw)
+    dao.save(raw, TicketKey=ticket_key, Host=host)
 
     # 5.
     cache.delete_memoized(get_all_raw)
-    cache.delete_memoized(get_raw_by_ticketkey, raw['TicketKey'])
-    cache.delete_memoized(get_raw_by_ticketkey_host, raw['TicketKey'], raw['Host'])
+    cache.delete_memoized(get_raw_by_ticketkey, ticket_key)
+    cache.delete_memoized(get_raw_by_ticketkey_host, ticket_key, host)
 
     return response.created()

--- a/dcsqa/response.py
+++ b/dcsqa/response.py
@@ -1,27 +1,35 @@
-import json
-import decimal
+import simplejson as json
 from flask import make_response
 from flask.ext.api import status
+from flask import jsonify
 
 
 def get_json(obj):
-    def _convert_decimal_to_int(obj):
-        if isinstance(obj, decimal.Decimal):
-            return int(obj)
-
-    if obj is not None:
-        response = make_response(json.dumps(obj, default=_convert_decimal_to_int))
-    else:
-        response = make_response('', status.HTTP_204_NO_CONTENT)
-
-    response.mimetype = 'application/json'
-
+    response_status = status.HTTP_204_NO_CONTENT if obj is None else status.HTTP_200_OK
+    response = jsonify({
+        "status": response_status,
+        "errorMessage": "",
+        "result": obj
+    })
+    response.status_code = response_status
     return response
 
 
 def bad_request(message):
-    return make_response(message, status.HTTP_400_BAD_REQUEST)
+    response = jsonify({
+        "status": status.HTTP_400_BAD_REQUEST,
+        "errorMessage": message
+    })
+    response.status_code = status.HTTP_400_BAD_REQUEST
+    return response
 
 
 def created():
-    return make_response('ok', status.HTTP_201_CREATED)
+    response = jsonify({
+        "status": status.HTTP_201_CREATED,
+        "errorMessage": ""
+    })
+    response.status_code = status.HTTP_201_CREATED
+    return response
+
+

--- a/dcsqa/response.py
+++ b/dcsqa/response.py
@@ -12,7 +12,12 @@ def get_json(obj):
             return int(obj)
 
     if obj is not None:
-        response = make_response(json.dumps(obj, default=_convert_decimal_to_int))
+        result = {
+            "status": status.HTTP_200_OK,
+            "errorMessage": "",
+            "result": obj
+        }
+        response = make_response(json.dumps(result, default=_convert_decimal_to_int))
     else:
         # Response does not contain any data
         response = make_response()

--- a/dcsqa/response.py
+++ b/dcsqa/response.py
@@ -1,17 +1,25 @@
-import simplejson as json
+import json
+import decimal
 from flask import make_response
 from flask.ext.api import status
 from flask import jsonify
 
 
 def get_json(obj):
-    response_status = status.HTTP_204_NO_CONTENT if obj is None else status.HTTP_200_OK
-    response = jsonify({
-        "status": response_status,
-        "errorMessage": "",
-        "result": obj
-    })
-    response.status_code = response_status
+
+    def _convert_decimal_to_int(obj):
+        if isinstance(obj, decimal.Decimal):
+            return int(obj)
+
+    if obj is not None:
+        response = make_response(json.dumps(obj, default=_convert_decimal_to_int))
+    else:
+        # Response does not contain any data
+        response = make_response()
+        response.status_code = status.HTTP_204_NO_CONTENT
+
+    response.mimetype = 'application/json'
+
     return response
 
 

--- a/dcsqa/result.py
+++ b/dcsqa/result.py
@@ -47,8 +47,8 @@ def get_result_by_ticketkey_host(ticket_key, host):
     return response.get_json(result)
 
 
-@result_blueprint.route('', methods=['POST'])
-def set_result_by_ticketkey_host():
+@result_blueprint.route('/<ticket_key>/<host>', methods=['POST'])
+def set_result_by_ticketkey_host(ticket_key, host):
 
     #
     # [Validation]
@@ -82,11 +82,11 @@ def set_result_by_ticketkey_host():
     dao = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RESULT_TABLE'],
                     logger=current_app.logger)
-    dao.save(result)
+    dao.save(result, TicketKey=ticket_key, Host=host)
 
     # 5.
     cache.delete_memoized(get_all_result)
-    cache.delete_memoized(get_result_by_ticketkey, result['TicketKey'])
-    cache.delete_memoized(get_result_by_ticketkey_host, result['TicketKey'], result['Host'])
+    cache.delete_memoized(get_result_by_ticketkey, ticket_key)
+    cache.delete_memoized(get_result_by_ticketkey_host, ticket_key, host)
 
     return response.created()

--- a/dcsqa/result.py
+++ b/dcsqa/result.py
@@ -2,9 +2,11 @@
 # coding: utf-8
 
 import response
+from auth import auth
 from flask import request, Blueprint, current_app
 from dcsqa.dao.table import DataTable
-from auth import auth
+from dcsqa.model.result import ResultData
+
 
 result_blueprint = Blueprint('result', __name__)
 
@@ -49,7 +51,7 @@ def set_result_by_ticketkey_host():
     # [Validation]
     #    1. must be content-type is applicaiton/json
     #    2. JSON must be parsed successfully
-    #    3. JSON must has TicketKey
+    #    3. validate JSON string
     #    4. save to DB
     #
 
@@ -62,20 +64,20 @@ def set_result_by_ticketkey_host():
     try:
         data = request.get_json()
     except Exception as ex:
-        #criteria_blueprint.loo
         current_app.logger.error(ex)
         return response.bad_request("invalid JSON format")
 
     # 3.
-    required_key = ['TicketKey', 'Host']
-    for key in required_key:
-        if key not in data:
-            return response.bad_request("{key} is not found".format(key=key))
+    try:
+        result = ResultData(**data).get_json()
+    except Exception as ex:
+        current_app.logger.error(ex)
+        return response.bad_request(ex.message)
 
     # 4.
     dao = DataTable(region_name=current_app.config['DYNAMODB_REGION'],
                     table_name=current_app.config['RESULT_TABLE'],
                     logger=current_app.logger)
-    result = dao.save(data)
+    result = dao.save(result)
 
     return response.created()

--- a/deployment/k8s-rc.json
+++ b/deployment/k8s-rc.json
@@ -1,0 +1,61 @@
+{
+	"kind":"ReplicationController",
+	"apiVersion":"v1beta3",
+	"metadata":{
+		"name":"qa-sample-service"
+	},
+	"spec":{
+		"replicas":1,
+		"selector":{
+			"name":"qa-sample-service"
+		},
+		"template":{
+			"metadata":{
+				"labels":{
+					"name":"qa-sample-service"
+				}
+				
+			},
+			"spec":{
+				"containers":[
+					{
+						"name":"qa-sample-service",
+						"image":"hidetosaito/qa-sample-service",
+						"imagePullPolicy":"Always",
+						"env":[
+							{
+								"name":"AWS_ACCESS_KEY_ID",
+								"value":"<your accesskey>"
+							},
+							{
+								"name":"AWS_SECRET_ACCESS_KEY",
+								"value":"<your secretkey>"
+							},
+							{
+								"name":"APP_SETTING",
+								"value":"config.DevelopmentContainerConfig"
+							},
+							{
+								"name":"PORT",
+								"value":"5000"
+							}
+							
+						],
+						"ports":[
+							{
+								"name":"http",
+								"containerPort":5000
+							}
+							
+						]
+						
+					}
+					
+				]
+				
+			}
+			
+		}
+		
+	}
+}

--- a/deployment/k8s-service.json
+++ b/deployment/k8s-service.json
@@ -1,0 +1,20 @@
+{
+	"apiVersion":"v1beta3",
+	"kind":"Service",
+	"metadata":{
+		"name":"qa-sample-service"
+	},
+	"spec":{
+		"ports":[
+			{
+				"protocol":"TCP",
+				"port":5000,
+				"nodePort":30080
+			}
+		],
+		"type":"NodePort",
+		"selector":{
+			"name":"qa-sample-service"
+		}
+	}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ mock==1.1.2
 Flask-API==0.6.3
 Flask-HTTPAuth
 Flask-Cache
+simplejson
 # using moto#a63d7486173f3b717d35310ede5acfa87809deb2 for https://github.com/spulec/moto/issues/374
 https://github.com/spulec/moto/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ mock==1.1.2
 Flask-API==0.6.3
 Flask-HTTPAuth
 Flask-Cache
-simplejson
 Flask-Testing
 # using moto#a63d7486173f3b717d35310ede5acfa87809deb2 for https://github.com/spulec/moto/issues/374
 https://github.com/spulec/moto/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ Flask-API==0.6.3
 Flask-HTTPAuth
 Flask-Cache
 simplejson
+Flask-Testing
 # using moto#a63d7486173f3b717d35310ede5acfa87809deb2 for https://github.com/spulec/moto/issues/374
 https://github.com/spulec/moto/archive/master.zip

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'mock>=1.1.2',
         'Flask-API>=0.6.3',
         'Flask-HTTPAuth',
-        'simplejson',
         'nose',
         'Flask-Testing'
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'mock>=1.1.2',
         'Flask-API>=0.6.3',
         'Flask-HTTPAuth',
+        'simplejson',
         'nose'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Flask-API>=0.6.3',
         'Flask-HTTPAuth',
         'simplejson',
-        'nose'
+        'nose',
+        'Flask-Testing'
     ],
 )

--- a/tests/dcsqa/model/test_model.py
+++ b/tests/dcsqa/model/test_model.py
@@ -1,0 +1,94 @@
+import unittest
+from dcsqa.model import BaseObject
+from dcsqa.app import app
+
+
+class ModelTest(unittest.TestCase):
+
+    def setUp(self):
+        #
+        # to resolve 'working outside of application context' error when make_reponse
+        # refer to http://flask.pocoo.org/docs/0.10/appcontext/
+        #
+        app.config.from_object('config.TestConfig')
+        self.app_context = app.app_context()
+        self.app_context.push()
+        self.base_test_data = {
+            'TicketKey': 'test-1',
+            'Host': 'test-host'
+        }
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    def test_key(self):
+        class TestData(BaseObject):
+            props = {
+                'TicketKey': (basestring, True),
+                'Host': (basestring, True),
+            }
+
+        # test no required 'Host'
+        test_data = {
+            'TicketKey': 'test-1'
+        }
+        with self.assertRaises(ValueError) as ex:
+            fail = TestData(**test_data).get_json()
+        self.assertEqual("Properties Host is required in type <type 'basestring'>", ex.exception.message)
+
+        # test success
+        obj = TestData(**self.base_test_data)
+        self.assertIsInstance(obj, TestData)
+        self.assertEquals(obj.get_json(), self.base_test_data)
+
+    def test_bool(self):
+        class TestBooleanData(BaseObject):
+            props = {
+                'TicketKey': (basestring, True),
+                'Host': (basestring, True),
+                'Unrequired_boolean': (bool, False),
+                'Required_boolean': (bool, True)
+            }
+
+        # test no required boolean
+        with self.assertRaises(ValueError) as ex:
+            fail = TestBooleanData(**self.base_test_data).get_json()
+        self.assertEqual("Properties Required_boolean is required in type <type 'bool'>", ex.exception.message)
+
+        # test success
+        self.base_test_data['Required_boolean'] = True
+        obj = TestBooleanData(**self.base_test_data)
+        self.assertIsInstance(obj, TestBooleanData)
+        self.assertEquals(obj.get_json(), self.base_test_data)
+
+        # test unrequired field
+        self.base_test_data['Unrequired_boolean'] = True
+        obj = TestBooleanData(**self.base_test_data)
+        self.assertIsInstance(obj, TestBooleanData)
+        self.assertEquals(obj.get_json(), self.base_test_data)
+
+    def test_list(self):
+        class TestListData(BaseObject):
+            props = {
+                'TicketKey': (basestring, True),
+                'Host': (basestring, True),
+                'Unrequired_list': (list, False),
+                'Required_list': (list, True)
+            }
+
+        # test no required list
+        with self.assertRaises(ValueError) as ex:
+            fail = TestListData(**self.base_test_data).get_json()
+        self.assertEqual("Properties Required_list is required in type <type 'list'>", ex.exception.message)
+
+        # test success
+        self.base_test_data['Required_list'] = [{'1': 1, '2': 2}, {'2': 2, '3': 3}]
+        obj = TestListData(**self.base_test_data)
+        self.assertIsInstance(obj, TestListData)
+        self.assertEquals(obj.get_json(), self.base_test_data)
+
+        # test unrequired field
+        self.base_test_data['Unrequired_list'] = [{'1': 1, '2': 2}, {'2': 2, '3': 3}]
+        obj = TestListData(**self.base_test_data)
+        self.assertIsInstance(obj, TestListData)
+        self.assertEquals(obj.get_json(), self.base_test_data)

--- a/tests/dcsqa/test_raw.py
+++ b/tests/dcsqa/test_raw.py
@@ -63,21 +63,13 @@ class RawRequestTest(unittest.TestCase):
         self.assertEqual(204, self.app.get('/zenoss/v1/raw', headers=self._get_auth_header()).status_code)
 
         # test post 400 wrong header
-        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(),
-                                 data=dict(TickeKey='testKey', Host='test'),
-                                 follow_redirects=True)
+        response = self.app.post('/zenoss/v1/raw/testKey/test', headers=self._get_auth_header(),
+                                 data=dict(Alert=['4']), follow_redirects=True)
         self.assertEqual(400, response.status_code)
-        self.assertEqual("please send application/json", response.data)
-
-        # test post 400 wrong key
-        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(json=True),
-                                 data=json.dumps(dict(TicketKey='testKey')), follow_redirects=True)
-        self.assertEqual(400, response.status_code)
-        self.assertIn("required", response.data)
+        self.assertIn("please send application/json", response.data)
 
         # test success
-        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(json=True),
-                                 data=json.dumps(dict(TicketKey='testKey', Host='test')),
-                                 follow_redirects=True)
+        response = self.app.post('/zenoss/v1/raw/testKey/test', headers=self._get_auth_header(json=True),
+                                 data=json.dumps(dict(Alert=['4'])), follow_redirects=True)
         self.assertEqual(201, response.status_code)
 

--- a/tests/dcsqa/test_raw.py
+++ b/tests/dcsqa/test_raw.py
@@ -8,11 +8,12 @@ from moto.dynamodb2 import mock_dynamodb2
 from moto.sqs import mock_sqs
 from dcsqa.dao.queue import Queue
 
-class CriteriaRequestTest(unittest.TestCase):
+
+class RawRequestTest(unittest.TestCase):
 
     def setUp(self):
         self.region_name = 'us-east-1'
-        self.table_name = 'test-Criteria'
+        self.table_name = 'test-RawData'
         app.config.from_object('config.TestConfig')
         self.app = app.test_client()
 
@@ -59,23 +60,23 @@ class CriteriaRequestTest(unittest.TestCase):
         self._create_table()
 
         # test no content
-        self.assertEqual(204, self.app.get('/criteria', headers=self._get_auth_header()).status_code)
+        self.assertEqual(204, self.app.get('/zenoss/v1/raw', headers=self._get_auth_header()).status_code)
 
         # test post 400 wrong header
-        response = self.app.post('/criteria', headers=self._get_auth_header(),
+        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(),
                                  data=dict(TickeKey='testKey', Host='test'),
                                  follow_redirects=True)
         self.assertEqual(400, response.status_code)
         self.assertEqual("please send application/json", response.data)
 
         # test post 400 wrong key
-        response = self.app.post('/criteria', headers=self._get_auth_header(json=True),
+        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(json=True),
                                  data=json.dumps(dict(TicketKey='testKey')), follow_redirects=True)
         self.assertEqual(400, response.status_code)
-        self.assertEqual("Host is not found", response.data)
+        self.assertIn("required", response.data)
 
         # test success
-        response = self.app.post('/criteria', headers=self._get_auth_header(json=True),
+        response = self.app.post('/zenoss/v1/raw', headers=self._get_auth_header(json=True),
                                  data=json.dumps(dict(TicketKey='testKey', Host='test')),
                                  follow_redirects=True)
         self.assertEqual(201, response.status_code)

--- a/tests/dcsqa/test_response.py
+++ b/tests/dcsqa/test_response.py
@@ -22,7 +22,8 @@ class ResponseTest(TestCase):
                           u'OSType': u'linux', u'CPU': Decimal('0'),
                           u'DataPartition': [{u'name': u'/', u'size': Decimal('20000')},
                                              {u'type': u'SAS', u'local': True,
-                                              u'name': u'/trend', u'size': Decimal('80000')}]
+                                              u'name': u'/trend', u'size': Decimal('80000')}],
+                          u'AccountGroup': set([u'dcsqa', u'dcsrd'])
                          }]
 
         self.assertEqual(200, response.get_json(test_response).status_code)

--- a/tests/dcsqa/test_response.py
+++ b/tests/dcsqa/test_response.py
@@ -2,20 +2,20 @@ import unittest
 from dcsqa.app import app
 import dcsqa.response as response
 from decimal import Decimal
+from flask import Flask
+from flask.ext.testing import TestCase
 
-class ResponseTest(unittest.TestCase):
 
-    def setUp(self):
+class ResponseTest(TestCase):
+
+    def create_app(self):
         #
-        # to resolve 'working outside of application context' error when make_reponse
-        # refer to http://flask.pocoo.org/docs/0.10/appcontext/
+        # for making response
+        # refer to - http://pythonhosted.org/Flask-Testing/
         #
+        app = Flask(__name__)
         app.config.from_object('config.TestConfig')
-        self.app_context = app.app_context()
-        self.app_context.push()
-
-    def tearDown(self):
-        self.app_context.pop()
+        return app
 
     def test_get_json(self):
         test_response = [{u'Hostname': u'dcs-qauat01.sjdc', u'Memory': Decimal('0'),
@@ -30,9 +30,9 @@ class ResponseTest(unittest.TestCase):
         self.assertEqual(204, response.get_json(None).status_code)
 
     def test_bad_request(self):
-        self.assertEqual(400, response.bad_request("it's really bad").status_code)
-        self.assertEqual("it's really bad", response.bad_request("it's really bad").data)
+        test_response = response.bad_request("it's really bad")
+        self.assertEqual(400, test_response.status_code)
+        self.assertIn("it's really bad", response.bad_request("it's really bad").data)
 
     def test_created(self):
         self.assertEqual(201, response.created().status_code)
-        self.assertEqual("ok", response.created().data)


### PR DESCRIPTION
Hi @hidetosaito,

Please kindly help review below items.
* The API call would become `http://$ip:$port/zenoss/v1/criteria` for this version
* Format validation
- The POST data would remain the same, for instance 
`[POST] http://127.0.0.1:5000/zenoss/v1/raw`

```
{
   "Host":"dcs-qavm-c66.sjc1",
   "TicketKey":"test-112",
   "Processors":true,
   "ProductionState":"Project",
   "Template":[
      "Device*"
   ],
   "IPAddress":"10.1.1.1"
}
```
- the format definition will be described in `model/raw.py` with `props (type, required) tuple map`.
  if the field is required but without data or with wrong format, will throw the error immediately the the requester; if the field is not required (most are them are in raw and result table) and with wrong format, it will just show the warning and skip that field rather than reject the whole request. This would be helpful in the real case if zenoss qa-worker returns any unexpected data without crashing frontend deserialization.
```
WARNING in __init__ [/Users/fuko/Documents/workspace/github/qa-sample-service/dcsqa/model/__init__.py:35]:
Field IPAddress is required in type <type 'basestring'> but <type 'list'>, Skip
``` 

Thank you very much.

Regards,
Chloe