### PR TITLE
update to v1

### DIFF
--- a/deployment/k8s-rc.json
+++ b/deployment/k8s-rc.json
@@ -1,6 +1,6 @@
 {
 	"kind":"ReplicationController",
-	"apiVersion":"v1beta3",
+	"apiVersion":"v1",
 	"metadata":{
 		"name":"qa-sample-service"
 	},

--- a/deployment/k8s-service.json
+++ b/deployment/k8s-service.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion":"v1beta3",
+	"apiVersion":"v1",
 	"kind":"Service",
 	"metadata":{
 		"name":"qa-sample-service"


### PR DESCRIPTION
Hi @msfuko 

This PR is for related to https://github.com/TrendMicroDCS/opsworks-recipes/pull/11 Kubernetes version up to **v1.0.1**. it doesn't allow to use ```v1beta3``` anymore, must use ```v1```


